### PR TITLE
Add an example SVG concatenation metadata renderer

### DIFF
--- a/src/svg-concat-renderer/SvgConcatRenderer.sol
+++ b/src/svg-concat-renderer/SvgConcatRenderer.sol
@@ -174,7 +174,7 @@ contract SvgConcatRenderer is
 
         string memory imageURI = bytes(info.imageURIBase).length == 0
             ? ""
-            : string.concat(info.imageURIBase, Strings.toHexString(tokenId, 2), info.imageURISuffix);
+            : string.concat(info.imageURIBase, Strings.toString(tokenId), info.imageURISuffix);
 
         return
             NFTMetadataRenderer.createMetadataEdition({

--- a/src/svg-concat-renderer/SvgConcatRenderer.sol
+++ b/src/svg-concat-renderer/SvgConcatRenderer.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/*
+    @@@@@@@@@@@@@@@@@@@   @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@*              @@@@@@   
+    @@@@@@@@@@@@@@@@@@  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@*           @@@@@@@@@   
+            @@@@@@@   @@@@@@@        @@@@@@@        @@@@@         @@@@@@@@@@@   
+        @@@@@@@    @@@@@@            @@@@@@     @@@@@@@      @@@@@@@@*@@@@@   
+        @@@@@@*       @@@@@              @@@@@   @@@@@@@      @@@@@@@    @@@@@   
+    @@@@@@@*         @@@@@@            @@@@@@  @@@@@@     @@@@@@@@      @@@@@   
+    @@@@@@*           @@@@@@@        @@@@@@@    @@@@@@@ @@@@@@@         @@@@@   
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@       @@@@@@@@@@@           @@@@@   
+    *@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@           @@@@@@**            @@@@@ 
+ */
+
+import {IMetadataRenderer} from "zora-drops-contracts/interfaces/IMetadataRenderer.sol";
+import {IERC721Drop} from "zora-drops-contracts/interfaces/IERC721Drop.sol";
+import {IERC2981Upgradeable} from "zora-drops-contracts/ERC721Drop.sol";
+import {IERC721MetadataUpgradeable} from "zora-drops-contracts/../lib/openzeppelin-contracts-upgradeable/contracts/interfaces/IERC721MetadataUpgradeable.sol";
+import {NFTMetadataRenderer} from "zora-drops-contracts/utils/NFTMetadataRenderer.sol";
+import {MetadataRenderAdminCheck} from "zora-drops-contracts/metadata/MetadataRenderAdminCheck.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+/// @notice Contract for rendering concatenated SVG metadata
+/// @author Kolber <kolber@zora.co>
+contract SvgConcatRenderer is
+    IMetadataRenderer,
+    MetadataRenderAdminCheck
+{
+    /// @notice Storage for token edition information
+    struct TokenEditionInfo {
+        string description;
+        string imageURIBase;
+        string imageURISuffix;
+    }
+
+    /// @notice Event for updated Media URIs
+    event MediaURIsUpdated(
+        address indexed target,
+        address sender,
+        string imageURIBase,
+        string imageURISuffix
+    );
+
+    /// @notice Event for a new edition initialized
+    /// @dev admin function indexer feedback
+    event EditionInitialized(
+        address indexed target,
+        string description,
+        string imageURIBase,
+        string imageURISuffix
+    );
+
+    /// @notice Description updated for this edition
+    /// @dev admin function indexer feedback
+    event DescriptionUpdated(
+        address indexed target,
+        address sender,
+        string newDescription
+    );
+
+    /// @notice Token information mapping storage
+    mapping(address => TokenEditionInfo) public tokenInfos;
+
+    /// @notice Update media URIs
+    /// @param target target for contract to update metadata for
+    /// @param imageURIBase new image uri prefix
+    /// @param imageURISuffix new image uri suffix
+    function updateMediaURIs(
+        address target,
+        string memory imageURIBase,
+        string memory imageURISuffix
+    ) external requireSenderAdmin(target) {
+        tokenInfos[target].imageURIBase = imageURIBase;
+        tokenInfos[target].imageURISuffix = imageURISuffix;
+        emit MediaURIsUpdated({
+            target: target,
+            sender: msg.sender,
+            imageURIBase: imageURIBase,
+            imageURISuffix: imageURISuffix
+        });
+    }
+
+    /// @notice Admin function to update description
+    /// @param target target description
+    /// @param newDescription new description
+    function updateDescription(address target, string memory newDescription)
+        external
+        requireSenderAdmin(target)
+    {
+        tokenInfos[target].description = newDescription;
+
+        emit DescriptionUpdated({
+            target: target,
+            sender: msg.sender,
+            newDescription: newDescription
+        });
+    }
+
+    /// @notice Default initializer for edition data from a specific contract
+    /// @param data data to init with
+    function initializeWithData(bytes memory data) external {
+        // data format: description, imageURIBase, imageURISuffix
+        (
+            string memory description,
+            string memory imageURIBase,
+            string memory imageURISuffix
+        ) = abi.decode(data, (string, string, string));
+
+        require(bytes(imageURIBase).length > 0, "imageURIBase is required");
+        require(bytes(imageURISuffix).length > 0, "imageURISuffix is required");
+
+        tokenInfos[msg.sender] = TokenEditionInfo({
+            description: description,
+            imageURIBase: imageURIBase,
+            imageURISuffix: imageURISuffix
+        });
+
+        emit EditionInitialized({
+            target: msg.sender,
+            description: description,
+            imageURIBase: imageURIBase,
+            imageURISuffix: imageURISuffix
+        });
+    }
+
+    /// @notice Contract URI information getter
+    /// @return contract uri (if set)
+    function contractURI() external view override returns (string memory) {
+        address target = msg.sender;
+
+        string memory imageURI = tokenInfos[target].imageURIBase;
+        string memory imageURISuffix = tokenInfos[target].imageURISuffix;
+        if (bytes(imageURI).length > 0) {
+            imageURI = string.concat(imageURI, "", imageURISuffix);
+        }
+
+        (address royaltyRecipient, uint256 royaltyCharged) = IERC2981Upgradeable(
+            target
+        ).royaltyInfo(0, 10_000);
+
+        return
+            NFTMetadataRenderer.encodeContractURIJSON({
+                name: IERC721MetadataUpgradeable(target).name(),
+                description: tokenInfos[target].description,
+                imageURI: imageURI,
+                animationURI: "",
+                royaltyBPS: royaltyCharged,
+                royaltyRecipient: royaltyRecipient
+            });
+    }
+
+    /// @notice Token URI information getter
+    /// @param tokenId to get uri for
+    /// @return contract uri (if set)
+    function tokenURI(uint256 tokenId)
+        external
+        view
+        override
+        returns (string memory)
+    {
+        address target = msg.sender;
+
+        TokenEditionInfo memory info = tokenInfos[target];
+        IERC721Drop media = IERC721Drop(target);
+
+        uint256 maxSupply = media.saleDetails().maxSupply;
+
+        // For open editions, set max supply to 0 for renderer to remove the edition max number
+        // This will be added back on once the open edition is "finalized"
+        if (maxSupply == type(uint64).max) {
+            maxSupply = 0;
+        }
+
+        string memory imageURI = bytes(info.imageURIBase).length == 0
+            ? ""
+            : string.concat(info.imageURIBase, Strings.toHexString(tokenId, 2), info.imageURISuffix);
+
+        return
+            NFTMetadataRenderer.createMetadataEdition({
+                name: IERC721MetadataUpgradeable(target).name(),
+                description: info.description,
+                imageURI: imageURI,
+                animationURI: "",
+                tokenOfEdition: tokenId,
+                editionSize: maxSupply
+            });
+    }
+}
+

--- a/src/svg-concat-renderer/SvgConcatRenderer.sol
+++ b/src/svg-concat-renderer/SvgConcatRenderer.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.8.13;
 import {IMetadataRenderer} from "zora-drops-contracts/interfaces/IMetadataRenderer.sol";
 import {IERC721Drop} from "zora-drops-contracts/interfaces/IERC721Drop.sol";
 import {IERC2981Upgradeable} from "zora-drops-contracts/ERC721Drop.sol";
-import {IERC721MetadataUpgradeable} from "zora-drops-contracts/../lib/openzeppelin-contracts-upgradeable/contracts/interfaces/IERC721MetadataUpgradeable.sol";
+import {IERC721MetadataUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/interfaces/IERC721MetadataUpgradeable.sol";
 import {NFTMetadataRenderer} from "zora-drops-contracts/utils/NFTMetadataRenderer.sol";
 import {MetadataRenderAdminCheck} from "zora-drops-contracts/metadata/MetadataRenderAdminCheck.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/svg-concat-renderer/SvgConcatRendererTest.sol
+++ b/test/svg-concat-renderer/SvgConcatRendererTest.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import {Test} from "forge-std/Test.sol";
+
+import {SvgConcatRenderer} from "../../src/svg-concat-renderer/SvgConcatRenderer.sol";
+
+import {ERC721Drop} from "zora-drops-contracts/ERC721Drop.sol";
+import {IERC721Drop} from "zora-drops-contracts/interfaces/IERC721Drop.sol";
+import {ERC721DropProxy} from "zora-drops-contracts/ERC721DropProxy.sol";
+import {IZoraFeeManager} from "zora-drops-contracts/interfaces/IZoraFeeManager.sol";
+import {FactoryUpgradeGate} from "zora-drops-contracts/FactoryUpgradeGate.sol";
+import {IERC721AUpgradeable} from "erc721a-upgradeable/IERC721AUpgradeable.sol";
+
+contract SvgConcatRendererTest is Test {
+    address constant OWNER_ADDRESS = address(0x123);
+    address constant RECIPIENT_ADDRESS = address(0x333);
+    ERC721Drop impl;
+    ERC721Drop drop;
+    SvgConcatRenderer renderer;
+
+    function setUp() public {
+        impl = new ERC721Drop(
+            IZoraFeeManager(address(0x0)),
+            address(0x0),
+            FactoryUpgradeGate(address(0x0))
+        );
+        renderer = new SvgConcatRenderer();
+    }
+
+    modifier withDrop(uint256 limit, bytes memory init) {
+        drop = ERC721Drop(
+            payable(
+                address(
+                    new ERC721DropProxy(
+                        address(impl),
+                        abi.encodeWithSelector(
+                            ERC721Drop.initialize.selector,
+                            "SVG NFT",
+                            "SRC",
+                            OWNER_ADDRESS,
+                            address(0x0),
+                            200,
+                            200,
+                            IERC721Drop.SalesConfiguration({
+                                publicSaleStart: 0,
+                                publicSaleEnd: 0,
+                                presaleStart: 0,
+                                presaleEnd: 0,
+                                publicSalePrice: 0,
+                                maxSalePurchasePerAddress: 0,
+                                presaleMerkleRoot: 0x0
+                            }),
+                            renderer,
+                            init
+                        )
+                    )
+                )
+            )
+        );
+        _;
+    }
+
+    function testForDropThree()
+        public
+        withDrop(
+            201,
+            abi.encode(
+                "Testing Description",
+                "data:image/svg+xml,%3csvg font-family='monospace' xmlns='http://www.w3.org/2000/svg'%3e%3ctext x='0' y='15'%3eTest SVG ",
+                "%3c/text%3e%3c/svg%3e"
+            )
+        )
+    {
+        vm.startPrank(OWNER_ADDRESS);
+        drop.adminMint(RECIPIENT_ADDRESS, 200);
+        assertEq(
+            drop.tokenURI(1),
+            "data:application/json;base64,eyJuYW1lIjogIlNWRyBORlQgMS8yMDAiLCAiZGVzY3JpcHRpb24iOiAiVGVzdGluZyBEZXNjcmlwdGlvbiIsICJpbWFnZSI6ICJkYXRhOmltYWdlL3N2Zyt4bWwsJTNjc3ZnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyclM2UlM2N0ZXh0IHg9JzAnIHk9JzE1JyUzZVRlc3QgU1ZHIDB4MDAwMSUzYy90ZXh0JTNlJTNjL3N2ZyUzZSIsICJwcm9wZXJ0aWVzIjogeyJudW1iZXIiOiAxLCAibmFtZSI6ICJTVkcgTkZUIn19"
+        );
+        assertEq(
+            drop.tokenURI(2),
+            "data:application/json;base64,eyJuYW1lIjogIlNWRyBORlQgMi8yMDAiLCAiZGVzY3JpcHRpb24iOiAiVGVzdGluZyBEZXNjcmlwdGlvbiIsICJpbWFnZSI6ICJkYXRhOmltYWdlL3N2Zyt4bWwsJTNjc3ZnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyclM2UlM2N0ZXh0IHg9JzAnIHk9JzE1JyUzZVRlc3QgU1ZHIDB4MDAwMiUzYy90ZXh0JTNlJTNjL3N2ZyUzZSIsICJwcm9wZXJ0aWVzIjogeyJudW1iZXIiOiAyLCAibmFtZSI6ICJTVkcgTkZUIn19"
+        );
+        assertEq(
+            drop.tokenURI(199),
+            "data:application/json;base64,eyJuYW1lIjogIlNWRyBORlQgMTk5LzIwMCIsICJkZXNjcmlwdGlvbiI6ICJUZXN0aW5nIERlc2NyaXB0aW9uIiwgImltYWdlIjogImRhdGE6aW1hZ2Uvc3ZnK3htbCwlM2NzdmcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyUzZSUzY3RleHQgeD0nMCcgeT0nMTUnJTNlVGVzdCBTVkcgMHgwMGM3JTNjL3RleHQlM2UlM2Mvc3ZnJTNlIiwgInByb3BlcnRpZXMiOiB7Im51bWJlciI6IDE5OSwgIm5hbWUiOiAiU1ZHIE5GVCJ9fQ=="
+        );
+    }
+}


### PR DESCRIPTION
Adds a simple example of using onchain SVG concatenation to wrap an svg data-uri around the current tokenId.
Hopefully serves as an example of a simple, updatable onchain SVG renderer which can be easily extended for more advanced purposes. 🫡